### PR TITLE
ng-gettingstarted: bump Vulkan SDK to 1.3.268 for Windows

### DIFF
--- a/section-ng-gettingstarted.tex
+++ b/section-ng-gettingstarted.tex
@@ -237,16 +237,16 @@ https://wixtoolset.org/docs/wix3/
 pacman -S git wget mingw-w64-x86_64-cmake mingw-w64-x86_64-toolchain
 \end{lstlisting}
 
-\item Build glslang tags/sdk-1.3.224.1:
+\item Build glslang tags/vulkan-sdk-1.3.268.0:
 
 Launch MSYS2 or MINGW64 as Administrator only for this step (it is mandatory to do the install in default path C:\\VulkanSDK ...)
 \begin{lstlisting}[language=sh, numbers=none]
 # Windows mingw64 glslang build (as it is not fully integrated in
-# VulkanSDK-1.3.224.1 for Windows and built with Visual Studio 2017)
+# VulkanSDK-1.3.268.0 for Windows and built with Visual Studio 2017)
 cd ~
 git clone https://github.com/KhronosGroup/glslang.git
 cd glslang
-git checkout tags/sdk-1.3.224.1
+git checkout tags/vulkan-sdk-1.3.268.0
 git clone https://github.com/google/googletest.git External/googletest
 cd External/googletest
 git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
@@ -267,10 +267,10 @@ cmake --build . --config Release --target install
 Launch MSYS2 or MINGW64 as Administrator only for this step (it is mandatory to do the install in default path C:\\VulkanSDK ...)
 \begin{lstlisting}[language=sh, numbers=none]
 cd ~
-wget https://sdk.lunarg.com/sdk/download/1.3.224.1/windows/VulkanSDK-1.3.224.1-Installer.exe
-./VulkanSDK-1.3.224.1-Installer.exe --accept-licenses --default-answer \
+wget https://sdk.lunarg.com/sdk/download/1.3.268.0/windows/VulkanSDK-1.3.268.0-Installer.exe
+./VulkanSDK-1.3.268.0-Installer.exe --accept-licenses --default-answer \
 	--confirm-command install
-rm -f VulkanSDK-1.3.224.1-Installer.exe
+rm -f VulkanSDK-1.3.268.0-Installer.exe
 \end{lstlisting}
 
 \item Check out the code
@@ -284,7 +284,7 @@ git clone --recursive https://github.com/ngscopeclient/scopehal-apps
 
 \begin{lstlisting}[language=sh, numbers=none]
 cd ~/scopehal-apps/msys2
-export VK_SDK_PATH=/c/VulkanSDK/1.3.224.1
+export VK_SDK_PATH=/c/VulkanSDK/1.3.268.0
 export PATH=$VK_SDK_PATH/Bin:$PATH
 export VULKAN_SDK=$VK_SDK_PATH
 export GLSLANG_BUILD_PATH=~/glslang/build/install


### PR DESCRIPTION
This addresses a glslang build issue on 1.3.224 with GCC 13 (not specific to MINGW) due to missing cstdint include. Bump to a more recent (and tested) SDK in doc to resolve glslang build issue.

Reference: https://github.com/KhronosGroup/glslang/issues/3139