### PR TITLE
Windows uart support via libserialport

### DIFF
--- a/section-ng-gettingstarted.tex
+++ b/section-ng-gettingstarted.tex
@@ -301,7 +301,7 @@ pacman -S git wget mingw-w64-ucrt-x86\_64-cmake mingw-w64-ucrt-x86\_64-toolchain
 
 \item Install general dependencies:
 \begin{lstlisting}[language=sh, numbers=none]
-pacman -S mingw-w64-ucrt-x86\_64-libsigc++ mingw-w64-ucrt-x86\_64-cairomm mingw-w64-ucrt-x86\_64-yaml-cpp mingw-w64-ucrt-x86\_64-glfw mingw-w64-ucrt-x86\_64-catch
+pacman -S mingw-w64-ucrt-x86\_64-libsigc++ mingw-w64-ucrt-x86\_64-cairomm mingw-w64-ucrt-x86\_64-yaml-cpp mingw-w64-ucrt-x86\_64-glfw mingw-w64-ucrt-x86\_64-catch mingw-w64-ucrt-x86\_64-libserialport
 \end{lstlisting}
 
 \item Install Vulkan dependencies:


### PR DESCRIPTION
This is a part of a group of 3 PRs to add support for uart transport on Windows through libserialport.
Here is the compilation documentation update to add libserialport dependency.