### PR TITLE
provide a default suggestion of 'ninja -j4' for Windows builds... ~1GB RAM per job is probably sensible

### DIFF
--- a/section-ng-gettingstarted.tex
+++ b/section-ng-gettingstarted.tex
@@ -331,7 +331,7 @@ cd scopehal-apps
 mkdir build
 cd build
 cmake ..
-ninja
+ninja -j4
 \end{lstlisting}
 
 \item Optional, to build MSI installer: 


### PR DESCRIPTION
I was building on a Windows VM earlier, and kept getting failures. Realising it was running out of memory, I increased the RAM (8 GB to 16 GB) and took the opportunity to bump the threads too (12 to 32)... this still failed, due to memory exhaustion.

By default, `ninja` will choose `-j$(nproc)`, and I suspect many users will also run into this issue. In the end, I ran `ninja -j16`  (with 16 GB RAM), and it completed successfully.
This was a completely fresh Win 10 VM, so had nothing else running, so more busy systems may appreciate more headroom.

I'd suggest at least 1GB of RAM per `ninja` job, but followed suit with the Linux builds that just specify `-j4` with no commentary in the docs.

This screenshot is a full build on the VM described here (`ninja clean && ninja -j16`), peaking at ~90% utilization with a base of ~15%.

![image](https://github.com/user-attachments/assets/1ed801b8-fedc-4bb0-9a18-8f202dc5e538)