### PR TITLE
Removed duplicated hid dependency from Windows Getting Started section.

### DIFF
--- a/section-ng-gettingstarted.tex
+++ b/section-ng-gettingstarted.tex
@@ -307,7 +307,7 @@ pacman -S mingw-w64-ucrt-x86\_64-libsigc++ mingw-w64-ucrt-x86\_64-cairomm mingw-
 \item Install Vulkan dependencies:
 \begin{lstlisting}[language=sh, numbers=none]
 pacman -S mingw-w64-ucrt-x86\_64-vulkan-headers mingw-w64-ucrt-x86\_64-vulkan-loader mingw-w64-ucrt-x86\_64-shaderc \
-mingw-w64-ucrt-x86\_64-glslang mingw-w64-ucrt-x86\_64-spirv-tools mingw-w64-ucrt-x86\_64-hidapi
+mingw-w64-ucrt-x86\_64-glslang mingw-w64-ucrt-x86\_64-spirv-tools
 \end{lstlisting}
 
 \item Install FFTS:


### PR DESCRIPTION
Hi Andrew,

This removes the misplaced hidapi dependency from Vulkan dependency section on Windows Getting Started guide.

Best,

Frederic.